### PR TITLE
Made the line, column, and selection information more clear.

### DIFF
--- a/addon/appModules/notepad++/__init__.py
+++ b/addon/appModules/notepad++/__init__.py
@@ -30,7 +30,7 @@ class AppModule(appModuleHandler.AppModule):
 				return
 		except AttributeError:
 			pass
-	
+
 		if (
 		(obj.windowControlID == 1682 and obj.role == controlTypes.ROLE_EDITABLETEXT)
 		or
@@ -83,7 +83,6 @@ class AppModule(appModuleHandler.AppModule):
 			self.isAutocomplete=True
 			core.callLater(100, self.waitforAndReportDestruction,obj)
 		nextHandler()
-
 
 	def waitforAndReportDestruction(self, obj):
 		if obj.parent: #None when no parent.

--- a/addon/appModules/notepad++/editWindow.py
+++ b/addon/appModules/notepad++/editWindow.py
@@ -156,7 +156,7 @@ class EditWindow(EditableTextWithAutoSelectDetection):
 		else:
 			#Translators: Message shown when there are no more search results in this direction using the notepad++ find command.
 			speech.speakMessage(_("No more search results in this direction."))
-	
+
 	#Translators: when pressed, goes to    the Next search result in Notepad++
 	script_reportFindResult.__doc__ = _("Queries the next or previous search result and speaks the selection and current line of it.")
 	script_reportFindResult.category = "Notepad++"

--- a/addon/appModules/notepad++/editWindow.py
+++ b/addon/appModules/notepad++/editWindow.py
@@ -127,11 +127,11 @@ class EditWindow(EditableTextWithAutoSelectDetection):
 	script_goToFirstOverflowingCharacter.__doc__ = _("Moves to the first character that is after the maximum line length")
 	script_goToFirstOverflowingCharacter.category = "Notepad++"
 
+	lineInfoExpression = re.compile(r"^Ln\D+(\d\w*)\D+(\d\w*)\D+(\d\w*)\D+(\d\w*)")
 	def script_reportLineInfo(self, gesture):
 		lineInfo = self.parent.next.next.firstChild.getChild(2).name
 		# Get only the numbers we want from the statusBar.
-		lineInfoExpression = re.compile(r"^Ln\D+(\d\w*)\D+(\d\w*)\D+(\d\w*)\D+(\d\w*)")
-		lines, columns, selectedCharacters, selectedLines = lineInfoExpression.match(lineInfo).groups()
+		lines, columns, selectedCharacters, selectedLines = self.lineInfoExpression.match(lineInfo).groups()
 		#Translators: The line and column position of the cursor.
 		lineInfo = _("line %s column %s" % (lines, columns))
 		if (locale.atoi(selectedCharacters)):	# Test the number not the string.

--- a/addon/appModules/notepad++/editWindow.py
+++ b/addon/appModules/notepad++/editWindow.py
@@ -15,6 +15,8 @@ import textInfos
 import tones
 import ui
 import eventHandler
+import re
+import locale
 
 addonHandler.initTranslation()
 
@@ -126,7 +128,19 @@ class EditWindow(EditableTextWithAutoSelectDetection):
 	script_goToFirstOverflowingCharacter.category = "Notepad++"
 
 	def script_reportLineInfo(self, gesture):
-		ui.message(self.parent.next.next.firstChild.getChild(2).name) 
+		lineInfo = self.parent.next.next.firstChild.getChild(2).name
+		# Get only the numbers we want from the statusBar.
+		lineInfoExpression = re.compile(r"^Ln\D+(\d\w*)\D+(\d\w*)\D+(\d\w*)\D+(\d\w*)")
+		lines, columns, selectedCharacters, selectedLines = lineInfoExpression.match(lineInfo).groups()
+		#Translators: The line and column position of the cursor.
+		lineInfo = _("line %s column %s" % (lines, columns))
+		if (locale.atoi(selectedCharacters)):	# Test the number not the string.
+			#Translators: The number of characters selected.
+			lineInfo += _(" %s characters selected" % (selectedCharacters))
+			if (locale.atoi(selectedLines)):	# Test the number not the string.
+				#Translators: The number of lines selected.
+				lineInfo += _(" %s lines selected" % (selectedLines))
+		ui.message(lineInfo)
 
 	#Translators: Script that announces information about the current line.
 	script_reportLineInfo.__doc__ = _("speak the line info item on the status bar")


### PR DESCRIPTION
The message spoken by the script reportLineInfo is rather cryptic. This change makes the script return a message "line X column Y" and only include the number of selected characters and lines if there are any.