### PR TITLE
Show autocomplete suggestions in braille

### DIFF
--- a/addon/appModules/notepad++/__init__.py
+++ b/addon/appModules/notepad++/__init__.py
@@ -48,6 +48,7 @@ class AppModule(appModuleHandler.AppModule):
 		confspec = {
 			"maxLineLength" : "integer(min=0, default=80)",
 			"lineLengthIndicator" : "boolean(default=False)",
+			"brailleAutocompleteSuggestions" : "boolean(default=True)",
 		}
 		config.conf.spec["notepadPp"] = confspec
 		self.guiManager = addonGui.GuiManager()

--- a/addon/appModules/notepad++/addonGui.py
+++ b/addon/appModules/notepad++/addonGui.py
@@ -64,11 +64,16 @@ class SettingsDialog(gui.SettingsDialog):
 		self.maxLineLengthEdit.SetValue(str(config.conf["notepadPp"]["maxLineLength"]))
 		maxLineLengthSizer.AddMany([maxLineLengthLabel, self.maxLineLengthEdit])
 		settingsSizer.Add(maxLineLengthSizer, border=10, flag=wx.BOTTOM)
+		# Translators: A setting for enabling/disabling autocomplete suggestions in braille.
+		self.brailleAutocompleteSuggestionsCheckBox = wx.CheckBox(self, wx.NewId(), label=_("Show autocomplete &suggestions in braille"))
+		self.brailleAutocompleteSuggestionsCheckBox.SetValue(config.conf["notepadPp"]["brailleAutocompleteSuggestions"])
+		settingsSizer.Add(self.brailleAutocompleteSuggestionsCheckBox, border=10, flag=wx.BOTTOM)
 
 	def postInit(self):
 		self.lineLengthIndicatorCheckBox.SetFocus()
 
 	def onOk(self, evt):
 		config.conf["notepadPp"]["lineLengthIndicator"] = self.lineLengthIndicatorCheckBox.IsChecked()
+		config.conf["notepadPp"]["brailleAutocompleteSuggestions"] = self.brailleAutocompleteSuggestionsCheckBox.IsChecked()
 		config.conf["notepadPp"]["maxLineLength"] = int(self.maxLineLengthEdit.GetValue())
 		super(SettingsDialog, self).onOk(evt)

--- a/addon/appModules/notepad++/autocomplete.py
+++ b/addon/appModules/notepad++/autocomplete.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 from NVDAObjects.IAccessible  import IAccessible
 import nvwave
 import speech

--- a/addon/appModules/notepad++/autocomplete.py
+++ b/addon/appModules/notepad++/autocomplete.py
@@ -2,7 +2,8 @@
 from NVDAObjects.IAccessible  import IAccessible
 import nvwave
 import speech
-import braille, config
+import braille
+import config
 import os
 
 class AutocompleteList(IAccessible):

--- a/addon/appModules/notepad++/autocomplete.py
+++ b/addon/appModules/notepad++/autocomplete.py
@@ -1,6 +1,8 @@
+# coding: utf8
 from NVDAObjects.IAccessible  import IAccessible
 import nvwave
 import speech
+import braille, config
 import os
 
 class AutocompleteList(IAccessible):
@@ -8,4 +10,5 @@ class AutocompleteList(IAccessible):
 	def event_selection(self):
 		speech.cancelSpeech()
 		speech.speakText(self.name)
-	
+		if config.conf["notepadPp"]["brailleAutocompleteSuggestions"]:
+			braille.handler.message(u'⣏ %s ⣹' % self.name)


### PR DESCRIPTION
I propose you my minor modification on this add-on that I use daily.
This change provides the possibility to show autocomplete suggestions in Braille.
I have also added a setting to enable / disable this.
However, I have incorrectly positioned the new option in the addon's settings dialog. I'm completely incompetent for this.