### PR TITLE
Support NVDA >= 2018.3 - wx 4 (#15)

### DIFF
--- a/addon/appModules/notepad++/addonGui.py
+++ b/addon/appModules/notepad++/addonGui.py
@@ -42,7 +42,7 @@ class GuiManager(object):
 			gui.mainFrame.sysTrayIcon.preferencesMenu.RemoveItem(self.prefsMenuItem)
 			#If we die, so did the app. If the user relaunches, so should we.
 			GuiManager.isMultiInst = False
-		except wx.PyDeadObjectError:
+		except:  # wx.PyDeadObjectError is replaced by RuntimeError as of wx 4
 			pass
 
 class SettingsDialog(gui.SettingsDialog):


### PR DESCRIPTION
Fixes #15

Remove reference to `wx.PyDeadObjectError`, replaced by `RuntimeError` as of
wx 4.

There probably are more elegant/robust way of doing it than the proposed bare except, but this is functional for what it is worth.