### PR TITLE
Updated French localization and documentation

### DIFF
--- a/addon/doc/fr/readme.md
+++ b/addon/doc/fr/readme.md
@@ -1,6 +1,6 @@
-# Notepad++ Module complémentaire pour NVDA #
+# Notepad++ Extension pour NVDA #
 
-Ce module complémentaire améliore l'accessibilité de notepad++. Notepad++ est un éditeur de texte pour windows, et possède de nombreuses fonctionnalités. Pour en savoir plus à ce sujet aller sur <https://notepad-plus-plus.org/>
+Cette extension améliore l'accessibilité de notepad++. Notepad++ est un éditeur de texte pour windows, et possède de nombreuses fonctionnalités. Pour en savoir plus à ce sujet aller sur <https://notepad-plus-plus.org/>
 
 ## Caractéristiques :
 
@@ -14,10 +14,9 @@ Vous pouvez définir autant de signets que vous souhaitez.
 
 ### Annonce de longueur de ligne maximale
 
-Notepad++ a une règle qui peut être utilisée pour vérifier la longueur de la ligne. Toutefois, cette fonctionnalité n’est ni accessibles ni significatif pour les utilisateurs aveugles, donc ce module complémentaire a un indicateur pour la longueur de ligne audible
-qui émet un bip chaque fois qu’une ligne est plus longue que le nombre de caractères spécifié.
+Notepad ++ a une règle qui peut être utilisée pour vérifier la longueur d'une ligne. Cependant, cette fonctionnalité n’est ni accessible ni significative pour les utilisateurs non-voyants, Par conséquent, cette extension dispose d'un indicateur de longueur de ligne audible qui émet un bip lorsqu'une ligne est plus longue que le nombre de caractères spécifié.
 
-Pour activer cette fonctionnalité, tout d’abord activer Notepad++, puis allez dans le menu NVDA et activer Notepad++ dans le menu paramètres. Cocher la case "Activer l'indicateur de longueur de ligne" et changer le nombre maximum de caractères que nécessaire. Lorsque la fonctionnalité est activée, vous entendrez un bip lors du défilement à travers des lignes qui sont trop longues ou des caractères qui dépassent la longueur maximale. Vous pouvez également appuyer sur NVDA+g pour aller jusqu’au premier caractère débordant sur la ligne active.
+Pour activer cette fonctionnalité, tout d’abord activer Notepad++, puis allez dans le menu NVDA et activer Notepad++ dans le menu paramètres. Cocher la case "Activer l'indicateur de longueur de ligne" et modifiez le nombre maximal de caractères si nécessaire. Lorsque la fonctionnalité est activée, vous entendrez un bip lors du déplacement à travers des lignes trop longues ou des caractères dépassant la longueur maximale. Vous pouvez également appuyer sur NVDA+g pour aller jusqu’au premier caractère débordant sur la ligne active.
 
 ### Se déplacer au délimiteur symétrique
 
@@ -33,20 +32,13 @@ La fonctionnalité de la saisie automatique de Notepad++ n'est pas accessible pa
 2. En appuyant sur les flèches bas/haut il lira le texte suggéré suivant/précédent. 
 3. Le texte recommandé est verbalisé lorsque les suggestions apparaissent.
 
-### Mappeur de raccourcis clavier
-
-Parfois, vous devez ajouter ou modifier les raccourcis clavier dans Notepad++. 
-Par exemple, vous pouvez enregistrer une macro pour supprimer le dernier caractère d'une ligne sur chaque ligne.
-Si vous définissez un raccourci clavier pour cette macro, ou si vous souhaitez modifier un raccourci clavier pour une autre commande dans l'éditeur, vous allez dans le menu préférences, puis allez dans la boîte de dialogue des raccourcis clavier.
-Malheureusement, la boîte de dialogue des raccourcis clavier n'est pas conviviale avec NVDA par défaut. Ce module complémentaire rend cette boîte de dialogue accessible. Vous pouvez tabuler entre les composants et appuyez sur les touches fléchées pour manipuler les contrôles comme vous le feriez pour toute autre boîte de dialogue.
-
 ### Recherche Incrémentielle
 
 L'une des caractéristiques les plus intéressantes de notepad++ est la possibilité d'utiliser la recherche incrémentielle. 
-La recherche incrémentielle est un mode de recherche dans lequel vous recherchez une phrase de test en tapant dans le champ d'édition et le document défile pour vous montrer la recherche en temps réel. 
-Pendant que vous tapez, le document défile pour afficher la ligne de texte avec l'expression la plus probable que vous recherchez. Il met également en évidence le texte qui correspond.
+La recherche incrémentielle est un mode de recherche dans lequel vous recherchez une phrase-test en tapant dans le champ d'édition, et le document se déplace en vous montrant la recherche en temps réel.  
+Pendant que vous tapez, le document se déplace pour afficher la ligne de texte avec la phrase la plus probable que vous recherchez. Il met également en évidence le texte qui correspond.
 Le programme vous indique également combien de correspondances ont été détectées. Il y a des boutons pour se déplacer au correspondance suivante et précédente.
-Au fur et à mesure que vous tapez, NVDA annoncera la ligne de texte dans lequelle notepad++ a détecté un résultat de recherche. NVDA annonce également le nombre de correspondances, mais uniquement si le nombre de correspondances a changé. 
+Au fur et à mesure que vous tapez, NVDA annoncera la ligne de texte que notepad ++ a détectée dans les résultats de la recherche. NVDA annonce également le nombre de correspondances, mais uniquement si le nombre de correspondances a changé. 
 Lorsque vous avez trouvé la ligne de texte que vous voulez, il suffit d'appuyer sur Echap, et cette ligne de texte sera sur votre curseur.
 Pour lancer cette boîte de dialogue, sélectionnez Recherche Incrémentielle dans le menu Recherche, ou appuyez sur alt+contrôle+i.
 
@@ -56,7 +48,7 @@ Appuyer sur NVDA+maj+\ (barre oblique inverser) à tout moment il va annoncé ce
 
 * le numéro de ligne
 * le numéro de colonne C'EST À DIRE. Jusqu'où vous êtes éloigné dans la ligne.
-* la taille de la sélection, (nombre de caractères sélectionnés horizontalement, suivi d'un symbole |, suivi du nombre de caractères sélectionnés verticalement, ce qui ferait un rectangle).
+* la taille de la sélection, (nombre de caractères sélectionnés horizontalement, suivi d'un symbole |, suivi du nombre de caractères sélectionnés verticalement, ce qui ferait un rectangle.
 
 ### Prise en charge de la fonction de recherche précédente / suivante
 
@@ -71,7 +63,7 @@ Notepad++ Nativement, ne supporte pas MarkDown (*.md) avec par exemple la colora
 Cependant, vous pouvez prévisualiser ce contenu comme un message consultable si vous appuyez sur NVDA+h (Échap pour fermer le message). 
 Appuyez sur NVDA+maj+h pour l'ouvrir dans votre navigateur standard. 
 Certaines extensions Markdown populaires telles que PHP Extra ou TOC sont prises en charge. 
-Il fonctionne également avec (single-paged) Html. 
+Il fonctionne également avec (à partir d'une seule page) Html. 
 
 Pour l'essayer, copiez le bloc suivant, collez-le dans un nouveau document Notepad ++ et appuyez sur NVDA+h :
 
@@ -93,6 +85,6 @@ Pour l'essayer, copiez le bloc suivant, collez-le dans un nouveau document Notep
 
 ## Raccourcis clavier Notepad++ non par défaut
 
-Ce module complémentaire suppose que Notepad++ est utilisé avec les touches de raccourci par défaut. 
-Si ce n'est pas le cas, S'il vous plaît, modifiez les touches de commandes de ce app module pour refléter vos commandes Notepad++ selon les besoins dans la boîte de dialogue Gestes de commandes de NVDA.
-Toutes les commandes du module complémentaire sont sous la section notepad++.
+Cette extension suppose que Notepad++ est utilisé avec les touches de raccourci par défaut. 
+Si ce n'est pas le cas, S'il vous plaît, modifiez les touches de commandes de cette extension applicative pour refléter vos commandes Notepad++ selon les besoins dans la boîte de dialogue Gestes de commandes de NVDA.
+Toutes les commandes de l'extension sont sous la section notepad++.

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: NotepadPlusPlus 1.2-dev\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@freelists.org'\n"
-"POT-Creation-Date: 2017-09-05 06:07+0200\n"
-"PO-Revision-Date: 2017-09-05 09:45+0200\n"
+"POT-Creation-Date: 2019-04-30 22:50+0200\n"
+"PO-Revision-Date: 2019-04-30 22:59+0200\n"
 "Last-Translator: Rémy Ruiz <remyruiz@gmail.com>\n"
 "Language-Team: Rémy Ruiz <remyruiz@gmail.com>\n"
 "Language: fr\n"
@@ -16,61 +16,65 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: AppModules\n"
-"X-Poedit-SearchPath-1: globalPlugins/skype7\n"
 
 #: addon\appModules\notepad++\addonGui.py:30
 msgid "Notepad++..."
 msgstr "Notepad++..."
 
 #. Translators: Title for the settings dialog
-#: addon\appModules\notepad++\addonGui.py:48
+#: addon\appModules\notepad++\addonGui.py:50
 msgid "Notepad++ settings"
 msgstr "Paramètres Notepad++"
 
 #. Translators: A setting for enabling/disabling line length indicator.
-#: addon\appModules\notepad++\addonGui.py:55
+#: addon\appModules\notepad++\addonGui.py:57
 msgid "Enable &line length indicator"
 msgstr "Activer l'indicateur de &longueur de ligne"
 
 #. Translators: Setting for maximum line length used by line length indicator
-#: addon\appModules\notepad++\addonGui.py:60
+#: addon\appModules\notepad++\addonGui.py:62
 msgid "&Maximum line length:"
 msgstr "Longueur de ligne &maximale :"
 
+#. Translators: A setting for enabling/disabling autocomplete suggestions in braille.
+#: addon\appModules\notepad++\addonGui.py:68
+msgid "Show autocomplete &suggestions in braille"
+msgstr "Afficher les &suggestions de saisie semi-automatique en braille"
+
 #. Translators: when pressed, goes to the matching brace in Notepad++
-#: addon\appModules\notepad++\editWindow.py:65
+#: addon\appModules\notepad++\editWindow.py:71
 msgid "Goes to the brace that matches the one under the caret"
 msgstr "Aller à l'accolade qui correspond à celui sous le point d'insertion"
 
 #. Translators: Script to move to the next bookmark in Notepad++.
-#: addon\appModules\notepad++\editWindow.py:72
+#: addon\appModules\notepad++\editWindow.py:78
 msgid "Goes to the next bookmark"
 msgstr "Aller au signet suivant"
 
 #. Translators: Script to move to the next bookmark in Notepad++.
-#: addon\appModules\notepad++\editWindow.py:79
+#: addon\appModules\notepad++\editWindow.py:85
 msgid "Goes to the previous bookmark"
 msgstr "Aller au signet précédent"
 
 #. Translators: Script to move the cursor to the first character on the current line that exceeds the users maximum allowed line length.
-#: addon\appModules\notepad++\editWindow.py:135
+#: addon\appModules\notepad++\editWindow.py:141
 msgid "Moves to the first character that is after the maximum line length"
 msgstr ""
 "Se déplacer vers le premier caractère qui est après la longueur de ligne "
 "maximale"
 
 #. Translators: Script that announces information about the current line.
-#: addon\appModules\notepad++\editWindow.py:142
+#: addon\appModules\notepad++\editWindow.py:148
 msgid "Speak the line info item on the status bar"
 msgstr "Annonce l'élément information de ligne sur la barre d'état"
 
 #. Translators: Message shown when there are no more search results in this direction using the notepad++ find command.
-#: addon\appModules\notepad++\editWindow.py:154
+#: addon\appModules\notepad++\editWindow.py:160
 msgid "No more search results in this direction"
 msgstr "Aucun autre résultat de recherche dans cette direction"
 
 #. Translators: when pressed, goes to the Next search result in Notepad++
-#: addon\appModules\notepad++\editWindow.py:157
+#: addon\appModules\notepad++\editWindow.py:163
 msgid ""
 "Queries the next or previous search result and speaks the selection and "
 "current line of it"
@@ -80,13 +84,13 @@ msgstr ""
 
 #. Translators: The title of the browseable message
 #. Translators: Title for the default browser, instead of the file name
-#: addon\appModules\notepad++\editWindow.py:163
-#: addon\appModules\notepad++\editWindow.py:174
+#: addon\appModules\notepad++\editWindow.py:169
+#: addon\appModules\notepad++\editWindow.py:180
 msgid "Preview of MarkDown or HTML"
 msgstr "Aperçu de MarkDown ou HTML"
 
 #. Translators: interprets the edit window content as Markdown and shows it in the internal Browser
-#: addon\appModules\notepad++\editWindow.py:167
+#: addon\appModules\notepad++\editWindow.py:173
 msgid ""
 "Treat the edit window text as MarkDown and display it as browsable message"
 msgstr ""
@@ -94,7 +98,7 @@ msgstr ""
 "message navigable"
 
 #. Translators: interprets the edit window content as Markdown and shows it in the external (default)  Browser
-#: addon\appModules\notepad++\editWindow.py:186
+#: addon\appModules\notepad++\editWindow.py:192
 msgid ""
 "Treat the edit window text as MarkDown and display it as webpage in the "
 "default browser"
@@ -116,9 +120,9 @@ msgid ""
 "This addon improves the accessibility of Notepad ++. To learn more, press "
 "the add-on help button."
 msgstr ""
-"App Module pour Notepad++.\n"
-"Ce module complémentaire améliore l'accessibilité de Notepad ++. Pour en "
-"savoir plus, appuyez sur le bouton Aide de ce module complémentaire."
+"Extension applicative pour Notepad++.\n"
+"Cette extension améliore l'accessibilité de Notepad++. Pour en savoir plus, "
+"appuyez sur le bouton Aide de cette extension."
 
 #~ msgid "speak the line info item on the status bar"
 #~ msgstr "annonce l'élément information de ligne sur la barre d'état"


### PR DESCRIPTION
1. Updated French localization.
2. Updated French documentation. Note that there is a missing string that was added in 2.0 but isn't present in master (https://github.com/derekriemer/nvda-notepadPlusPlus/commit/7ccc977a4f10ba9fdc047f79ac2c71957fe3f8dc), not included in this PR.

This contribution was submitted by @blindhelp.
If any problem please comment.