### PR TITLE
Updated Spanish localization and translation

### DIFF
--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -1,4 +1,4 @@
-# Notepad++ Complemento para NVDA #
+﻿# Notepad++ Complemento para NVDA #
 
 Este complemento mejora la accesibilidad de notepad++. Notepad++ es un editor de texto para Windows, y tiene muchas características. Puedes obtener más información al respecto en <https://notepad-plus-plus.org/>
 
@@ -12,13 +12,13 @@ Para establecer un marcador, desde la línea que deseas marcar, pulsa control+f2
 Luego, cuando quieras regresar a este marcador, pulsa f2 para saltar al siguiente marcador, o shift+f2 para saltar hacia atrás al anterior.
 Puedes establecer tantos marcadores como desees.
 
-### Anuncio de longitud de línea máxima
+### Anuncio de longitud máxima de línea
 
-Notepad++ tiene una regla que se puede utilizar para comprobar la longitud de una línea. Sin embargo, esta característica no es ni accesible ni significativo para los usuarios ciegos, por lo que este complemento tiene un indicador de longitud de línea audible
-que emitirá un pitido cuando una línea es más larga que el número especificado de caracteres.
+Notepad++ tiene una regla que se puede utilizar para comprobar la longitud de una línea. Sin embargo, esta característica no es ni accesible ni significativa para los usuarios ciegos, por lo que este complemento tiene un indicador audible 
+de longitud de línea que emitirá un pitido cuando una línea sea más larga que el número especificado de caracteres.
 
-Para activar esta función, primero activa Notepad++, luego vas al menú de NVDA y activaNotepad++
-bajo el menú Opciones. Marca la casilla "Activar el indicador de longitud de línea" y cambiar el máximo número de caracteres según sea necesario. Cuando la función está activada, escuchará un pitido al desplazarte a través de líneas que son demasiado largas o caracteres que están sobre la longitud máxima. Alternativamente, puedes pulsar NVDA+g para saltar al primer carácter de desbordamiento en la línea activa.
+Para activar esta función, primero activa Notepad++, luego ve al menú de NVDA y pulsa Notepad++
+bajo el menú Opciones. Marca la casilla "Activar el indicador de longitud de línea" y cambia el número máximo de caracteres según sea necesario. Cuando la función esté activada, escucharás un pitido al desplazarte a través de líneas que sean demasiado largas o caracteres que estén más allá de la longitud máxima. Alternativamente, puedes pulsar NVDA+g para saltar al primer carácter de desbordamiento en la línea activa.
 
 ### Moverse al delimitador simétrico
 
@@ -30,39 +30,32 @@ Al pulsar este comando, NVDA leerá la línea en la que aterrizó y si la línea
 
 La funcionalidad de autocompletado de Notepad++ no es accesible por defecto. El autocompletado tiene muchos problemas, incluyendo que se muestra en una ventana flotante. Para hacer esta funcionalidad accesible, se hacen tres cosas. 
 
-1. Cuando aparece una sugerencia de autocompletado, un sonido como un deslizamiento es reproducido. El sonido inverso se hace cuando desaparecen las sugerencias.
+1. Cuando aparece una sugerencia de autocompletado, se reproduce un sonido como un deslizamiento. El sonido inverso se hace cuando desaparecen las sugerencias.
 2. Al pulsar las flechas abajo/arriba lee el texto sugerido siguiente/anterior. 
 3. El texto recomendado se verbaliza cuando aparecen las sugerencias.
-
-### Mapeador de atajos de teclado
-
-A veces tienes que agregar o cambiar los atajos de teclado en Notepad++. 
-Por ejemplo, puedes guardar una macro para eliminar el último carácter de una línea en cada líneaa.
-Si estableces un atajo de teclado para esta macro o deseas cambiar un atajo de teclado para otras órdenes de teclado en el editor, irás al menú Preferencias, luego vás al cuadro de diálogo de atajos de teclado.
- Desafortunadamente, el diálogo de atajos de teclado no es amigable con NVDA de forma predeterminada. Este complemento hace que este diálogo sea accesible. Puedes tabular entre los componentes y pulsar las teclas de flechas para manipular los controles como lo harías para cualquier otro diálogo.
 
 ### Búsqueda incremental
 
 Una de las caracteristicas mas interesantes de notepad++ es la capacidad para usar la busqueda incremental. 
-La búsqueda incremental es un modo de búsqueda en la que buscas una frase de prueba escribiendo en el campo de edición, y el documento se desplaza mostrandote la búsqueda en tiempo real. 
-Mientras escribe, el documento se desplaza para mostrar la línea de texto con la frase más probable que estas buscando. También resalta el texto que coincida.
-El programa también te muestra cuántas coincidencias han sido detectadas. Hay botones para desplazarse hacia la coincidencia siguiente y anterior.
-Mientras escribes, NVDA anunciará la línea de texto que notepad++ detectó en un resultado de búsqueda. NVDA anuncia también cuántas coincidencias hay, pero sólo si el número de coincidencias han cambiado. 
-Cuando has encontrado la línea de texto que quieras, simplemente pulsa escape, y esa línea de texto sera en tu cursor.
-Para lanzar este cuadro de diálogo, selecciona Búsqueda incremental Desde el menu Buscar, o pulsa alt+control+i.
+La búsqueda incremental es un modo de búsqueda en el que buscas una frase de prueba escribiendo en el campo de edición, y el documento se desplaza mostrandote la búsqueda en tiempo real. 
+Mientras escribe, el documento se desplaza para mostrar la línea de texto con la frase más probable que estás buscando. También resalta el texto que coincida.
+El programa también te muestra cuántas coincidencias se han detectado. Hay botones para desplazarse hacia la coincidencia siguiente y anterior.
+Mientras escribes, NVDA anunciará la línea de texto que notepad++ detectó en un resultado de búsqueda. NVDA anuncia también cuántas coincidencias hay, pero sólo si el número de coincidencias ha cambiado. 
+Cuando has encontrado la línea de texto que quieras, simplemente pulsa escape, y esa línea de texto estará en tu cursor.
+Para abrir este cuadro de diálogo, selecciona Búsqueda incremental Desde el menu Buscar, o pulsa alt+control+i.
 
 ### Anunciando información acerca de la línea actual
 
-Pulsando NVDA+shift+\ (barra inversa) en cualquier momento se anunciara lo siguiente:
+Pulsando NVDA+shift+\ (barra inversa) en cualquier momento se anunciará lo siguiente:
 
 * el número de línea
-* el número de la columna, es decir, cuan lejos estás en la línea.
-* el tamaño de la seleccion, (número de caracteres horizontalmente seleccionados, seguido por un símbolo, seguido por el número de caracteres seleccionados verticalmente, lo que haría un rectángulo).
-
+* el número de la columna, es decir, cuán lejos estás en la línea.
+* el tamaño de la seleccion, (número de caracteres horizontalmente seleccionados, seguido por un símbolo, seguido por el número de caracteres seleccionados verticalmente, lo que haría un rectángulo.
+ 
 ### Apoyo a la funcion de busqueda anterior / siguiente
 
 Por defecto, si pulsas control+f aparece el cuadro de diálogo Buscar. 
-Si tecleas un texto aquí y pulsas Intro, el texto en la ventana es seleccionado y el documento se desplaza hacia el resultado de la búsqueda siguiente.
+Si tecleas un texto aquí y pulsas Intro, el texto en la ventana se selecciona y el documento se desplaza hacia el resultado de la búsqueda siguiente.
 En Notepad++ puedes pulsar f3 o shift+f3 para repetir la búsqueda en dirección hacia adelante o hacia atrás respectivamente. 
 NVDA leerá tanto la línea actual, y la selección dentro de la línea que representa el texto encontrado.
 
@@ -72,7 +65,7 @@ Notepad++ No es compatible con MarkDown (*.md) p.ej. el resaltado del lenguaje.
 Sin embargo, puede obtener una vista previa de dicho contenido como mensaje navegable si pulsa NVDA+h (Escape para cerrar el mensaje). 
 Si pulsa NVDA+shift+h, la abrirá en su navegador estándar. 
 Algunas extensiones de Markdown populares como PHP Extra o TOC son compatibles. 
-Funciona también con (single-paged) Html. 
+Funciona también con (de una sola página) Html. 
 
 Para probarlo, copie el siguiente bloque, péguelo en un nuevo documento de Notepad ++ y presione NVDA+h:
 
@@ -82,7 +75,7 @@ Para probarlo, copie el siguiente bloque, péguelo en un nuevo documento de Note
     ## Donde empezó...  
     > Hace mucho tiempo,  
     > en un país extranjero.  
-    ## Y adonde fue después  
+    ## Y adónde fue después  
     1. Primera etapa  
     2. Segunda etapa  
     ## Eventualmente se convirtió en  
@@ -95,5 +88,5 @@ Para probarlo, copie el siguiente bloque, péguelo en un nuevo documento de Note
 ## Atajos de teclado de Notepad++ no por defecto
 
 Este complemento supone que Notepad++ es utilizado con las teclas de acceso directo por defecto. 
-Si este no es el caso, por favor modifica las teclas de órdenes de esta app module para reflejar tus órdenes Notepad++ según las necesidades en el cuadro de diálogo Gestos de Entrada de NVDA.
+Si este no es el caso, por favor modifica las teclas de órdenes de este app module para reflejar tus órdenes de Notepad++ según necesites en el cuadro de diálogo Gestos de Entrada de NVDA.
 Todas las órdenes del complemento están bajo la sección de notepad++.

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: NotepadPlusPlus 1.2-dev\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@freelists.org'\n"
-"POT-Creation-Date: 2017-09-05 06:37+0200\n"
-"PO-Revision-Date: 2017-09-05 09:44+0200\n"
+"POT-Creation-Date: 2019-04-30 22:40+0200\n"
+"PO-Revision-Date: 2019-04-30 22:47+0200\n"
 "Last-Translator: Rémy Ruiz <remyruiz@gmail.com>\n"
 "Language-Team: Rémy Ruiz <remyruiz@gmail.com>\n"
 "Language: es\n"
@@ -16,60 +16,64 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: AppModules\n"
-"X-Poedit-SearchPath-1: globalPlugins/skype7\n"
 
 #: addon\appModules\notepad++\addonGui.py:30
 msgid "Notepad++..."
 msgstr "Notepad++..."
 
 #. Translators: Title for the settings dialog
-#: addon\appModules\notepad++\addonGui.py:48
+#: addon\appModules\notepad++\addonGui.py:50
 msgid "Notepad++ settings"
 msgstr "Opciones de Notepad++"
 
 #. Translators: A setting for enabling/disabling line length indicator.
-#: addon\appModules\notepad++\addonGui.py:55
+#: addon\appModules\notepad++\addonGui.py:57
 msgid "Enable &line length indicator"
 msgstr "Activar el indicador de &longitud de línea"
 
 #. Translators: Setting for maximum line length used by line length indicator
-#: addon\appModules\notepad++\addonGui.py:60
+#: addon\appModules\notepad++\addonGui.py:62
 msgid "&Maximum line length:"
-msgstr "Longitud de línea &máxima:"
+msgstr "Longitud &máxima de línea"
+
+#. Translators: A setting for enabling/disabling autocomplete suggestions in braille.
+#: addon\appModules\notepad++\addonGui.py:68
+msgid "Show autocomplete &suggestions in braille"
+msgstr "Mostrar &sugerencias de autocompletado en braille"
 
 #. Translators: when pressed, goes to the matching brace in Notepad++
-#: addon\appModules\notepad++\editWindow.py:65
+#: addon\appModules\notepad++\editWindow.py:71
 msgid "Goes to the brace that matches the one under the caret"
 msgstr "Ir a la llave correspondiente aquélla bajo el punto de inserción"
 
 #. Translators: Script to move to the next bookmark in Notepad++.
-#: addon\appModules\notepad++\editWindow.py:72
+#: addon\appModules\notepad++\editWindow.py:78
 msgid "Goes to the next bookmark"
 msgstr "Ir al siguiente marcador"
 
 #. Translators: Script to move to the next bookmark in Notepad++.
-#: addon\appModules\notepad++\editWindow.py:79
+#: addon\appModules\notepad++\editWindow.py:85
 msgid "Goes to the previous bookmark"
 msgstr "Ir al marcador anterior"
 
 #. Translators: Script to move the cursor to the first character on the current line that exceeds the users maximum allowed line length.
-#: addon\appModules\notepad++\editWindow.py:135
+#: addon\appModules\notepad++\editWindow.py:141
 msgid "Moves to the first character that is after the maximum line length"
 msgstr ""
-"Moverse al primer carácter que está después de la longitud de línea máxima"
+"Moverse al primer carácter que está después de la longitud máxima de línea"
 
 #. Translators: Script that announces information about the current line.
-#: addon\appModules\notepad++\editWindow.py:142
+#: addon\appModules\notepad++\editWindow.py:148
 msgid "Speak the line info item on the status bar"
 msgstr "Anuncia el elemento información de línea en la barra de estado"
 
 #. Translators: Message shown when there are no more search results in this direction using the notepad++ find command.
-#: addon\appModules\notepad++\editWindow.py:154
+#: addon\appModules\notepad++\editWindow.py:160
 msgid "No more search results in this direction"
 msgstr "No hay más resultados de búsqueda en esta dirección"
 
 #. Translators: when pressed, goes to the Next search result in Notepad++
-#: addon\appModules\notepad++\editWindow.py:157
+#: addon\appModules\notepad++\editWindow.py:163
 msgid ""
 "Queries the next or previous search result and speaks the selection and "
 "current line of it"
@@ -79,13 +83,13 @@ msgstr ""
 
 #. Translators: The title of the browseable message
 #. Translators: Title for the default browser, instead of the file name
-#: addon\appModules\notepad++\editWindow.py:163
-#: addon\appModules\notepad++\editWindow.py:174
+#: addon\appModules\notepad++\editWindow.py:169
+#: addon\appModules\notepad++\editWindow.py:180
 msgid "Preview of MarkDown or HTML"
 msgstr "Vista previa de MarkDown o HTML"
 
 #. Translators: interprets the edit window content as Markdown and shows it in the internal Browser
-#: addon\appModules\notepad++\editWindow.py:167
+#: addon\appModules\notepad++\editWindow.py:173
 msgid ""
 "Treat the edit window text as MarkDown and display it as browsable message"
 msgstr ""
@@ -93,7 +97,7 @@ msgstr ""
 "mensaje navegable"
 
 #. Translators: interprets the edit window content as Markdown and shows it in the external (default)  Browser
-#: addon\appModules\notepad++\editWindow.py:186
+#: addon\appModules\notepad++\editWindow.py:192
 msgid ""
 "Treat the edit window text as MarkDown and display it as webpage in the "
 "default browser"
@@ -116,7 +120,7 @@ msgid ""
 "the add-on help button."
 msgstr ""
 "App Module para Notepad++.\n"
-"Este complemento mejora la accesibilidad de Notepad ++. Para obtener más "
+"Este complemento mejora la accesibilidad de Notepad++. Para obtener más "
 "información pulsar el botón Ayuda del Complemento."
 
 #~ msgid "speak the line info item on the status bar"


### PR DESCRIPTION
1. Updated Spanish localization.
2. Updated Spanish documentation. Note that there is a missing string that was added in 2.0 but isn't present in master (https://github.com/derekriemer/nvda-notepadPlusPlus/commit/7ccc977a4f10ba9fdc047f79ac2c71957fe3f8dc), not included in this PR.

This contribution was submitted by @blindhelp.
If any problem please comment.