### PR TITLE
Updated German localization and translation

### DIFF
--- a/addon/doc/de/readme.md
+++ b/addon/doc/de/readme.md
@@ -39,17 +39,6 @@ Um diese Funktionalität zu erschliessen werden drei Dinge getan:
 2. Drücken der Pfeil nach unten/oben Taste verursacht ein Lesen des nächsten oder vorherigen Vorschlags. 
 3. Der empfohlene Text wird gesprochen sobald ein Vorschlag erscheint.
 
-### Tastatur
-
-Zuweilen möchten Sie Tastenkombinationen in Notepad++ ändern oder hinzufügen.
-Zum Beispiel könnten Sie ein Makro aufgezeichnet haben das das letzte Zeichen in jeder Zeile entfernt.
-Wollen Sie nun eine Tastenkombination für dieses Makro definieren oder generell eine bestehende Tastenkombination ändern,
-so gehen Sie gewöhnlich zu Optionen und dann auf Tastatur, woraufhin sich ein Dialog öffnet.
-Bedauerlicherweise ist dieser Dialog standardmässig nicht sehr freundlich zu NVDA.
-Diese Erweiterung macht ihn jedoch voll zugänglich.
-Mittels Tabulator können Sie zwischen den verschiedenen Komponenten hin und her wechseln und durch Betätigen der Pfeiltasten die Werte ändern,
-genau so wie Sie es von anderen Dialogen gewöhnt sind.
-
 ### Inkrementelle Suche
 
 Eine der interessantesten funktionen von Notepad++ ist die

--- a/addon/locale/de/LC_MESSAGES/nvda.po
+++ b/addon/locale/de/LC_MESSAGES/nvda.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 'NotepadPlusPlus' '1.2-dev'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@freelists.org'\n"
-"POT-Creation-Date: 2017-09-04 11:16+0200\n"
-"PO-Revision-Date: 2017-09-04 11:30+0200\n"
+"POT-Creation-Date: 2019-04-30 23:02+0200\n"
+"PO-Revision-Date: 2019-04-30 23:14+0200\n"
 "Last-Translator: Rémy Ruiz <remyruiz@gmail.com>\n"
 "Language-Team: Robert Hänggi <aarjay.robert@gmail.com>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.3\n"
+"X-Generator: Poedit 1.8.12\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: addon\appModules\notepad++\addonGui.py:30
@@ -23,53 +23,58 @@ msgid "Notepad++..."
 msgstr "Notepad++..."
 
 #. Translators: Title for the settings dialog
-#: addon\appModules\notepad++\addonGui.py:48
+#: addon\appModules\notepad++\addonGui.py:50
 msgid "Notepad++ settings"
 msgstr "Notepad++ Einstellungen"
 
 #. Translators: A setting for enabling/disabling line length indicator.
-#: addon\appModules\notepad++\addonGui.py:55
+#: addon\appModules\notepad++\addonGui.py:57
 msgid "Enable &line length indicator"
 msgstr "Aktiviere die Anzeige von überlangen Zei&len"
 
 #. Translators: Setting for maximum line length used by line length indicator
-#: addon\appModules\notepad++\addonGui.py:60
+#: addon\appModules\notepad++\addonGui.py:62
 msgid "&Maximum line length:"
 msgstr "&Maximal erlaubte Zeilenlänge:"
 
+#. Translators: A setting for enabling/disabling autocomplete suggestions in braille.
+#: addon\appModules\notepad++\addonGui.py:68
+msgid "Show autocomplete &suggestions in braille"
+msgstr "Zeige Auto-Komplettierung und &Vorchlge in Braille"
+
 #. Translators: when pressed, goes to the matching brace in Notepad++
-#: addon\appModules\notepad++\editWindow.py:65
+#: addon\appModules\notepad++\editWindow.py:71
 msgid "Goes to the brace that matches the one under the caret"
 msgstr "Geht zur Klammer, die zu derjenigen unter der Einfügemarke gehört"
 
 #. Translators: Script to move to the next bookmark in Notepad++.
-#: addon\appModules\notepad++\editWindow.py:72
+#: addon\appModules\notepad++\editWindow.py:78
 msgid "Goes to the next bookmark"
 msgstr "Geht zum nächsten Lesezeichen"
 
 #. Translators: Script to move to the next bookmark in Notepad++.
-#: addon\appModules\notepad++\editWindow.py:79
+#: addon\appModules\notepad++\editWindow.py:85
 msgid "Goes to the previous bookmark"
 msgstr "Geht zum vorherigen Lesezeichen"
 
 #. Translators: Script to move the cursor to the first character on the current line that exceeds the users maximum allowed line length.
-#: addon\appModules\notepad++\editWindow.py:135
+#: addon\appModules\notepad++\editWindow.py:141
 msgid "Moves to the first character that is after the maximum line length"
 msgstr ""
 "Bewegt die Einfügemarke zum ersten Zeichen nach der erlaubten Zeilenlänge"
 
 #. Translators: Script that announces information about the current line.
-#: addon\appModules\notepad++\editWindow.py:142
+#: addon\appModules\notepad++\editWindow.py:148
 msgid "Speak the line info item on the status bar"
 msgstr "Spricht die sich auf der Statuszeile befindliche Zeileninformation"
 
 #. Translators: Message shown when there are no more search results in this direction using the notepad++ find command.
-#: addon\appModules\notepad++\editWindow.py:154
+#: addon\appModules\notepad++\editWindow.py:160
 msgid "No more search results in this direction"
 msgstr "Keine weiteren Suchergebnisse in dieser Richtung"
 
 #. Translators: when pressed, goes to the Next search result in Notepad++
-#: addon\appModules\notepad++\editWindow.py:157
+#: addon\appModules\notepad++\editWindow.py:163
 msgid ""
 "Queries the next or previous search result and speaks the selection and "
 "current line of it"
@@ -79,13 +84,13 @@ msgstr ""
 
 #. Translators: The title of the browseable message
 #. Translators: Title for the default browser, instead of the file name
-#: addon\appModules\notepad++\editWindow.py:163
-#: addon\appModules\notepad++\editWindow.py:174
+#: addon\appModules\notepad++\editWindow.py:169
+#: addon\appModules\notepad++\editWindow.py:180
 msgid "Preview of MarkDown or HTML"
 msgstr "Vorschau von MarkDown oder Html Inhalten"
 
 #. Translators: interprets the edit window content as Markdown and shows it in the internal Browser
-#: addon\appModules\notepad++\editWindow.py:167
+#: addon\appModules\notepad++\editWindow.py:173
 msgid ""
 "Treat the edit window text as MarkDown and display it as browsable message"
 msgstr ""
@@ -93,7 +98,7 @@ msgstr ""
 "im internen Browser"
 
 #. Translators: interprets the edit window content as Markdown and shows it in the external (default)  Browser
-#: addon\appModules\notepad++\editWindow.py:186
+#: addon\appModules\notepad++\editWindow.py:192
 msgid ""
 "Treat the edit window text as MarkDown and display it as webpage in the "
 "default browser"


### PR DESCRIPTION
1. Updated German localization.
2. Updated German documentation. Note that there is a missing string that was added in 2.0 but isn't present in master (https://github.com/derekriemer/nvda-notepadPlusPlus/commit/7ccc977a4f10ba9fdc047f79ac2c71957fe3f8dc), not included in this PR.

This contribution was authored by @robert-j-h and submitted by @blindhelp.
If any problem please comment.