### PR TITLE
Fix typo causing exception during termination.

### DIFF
--- a/addon/appModules/notepad++/__init__.py
+++ b/addon/appModules/notepad++/__init__.py
@@ -56,7 +56,7 @@ class AppModule(appModuleHandler.AppModule):
 		self.isAutocomplete=False
 
 	def terminate(self):
-		self.guiManager = none
+		self.guiManager = None
 
 	def requestEvents(self):
 		#We need these for autocomplete


### PR DESCRIPTION
In the `terminate` method, we had `self.guiManager = none` (none with a lower case n).